### PR TITLE
StopWatch Implementation - Nina Huang

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,11 +1,12 @@
 import { StatusBar } from 'expo-status-bar';
 import { StyleSheet, Text, View } from 'react-native';
+import StopWatch from './src/StopWatch';
 
 export default function App() {
   return (
     <View style={styles.container}>
-      <Text>Open up App.tsx to start working on your app!</Text>
-      <StatusBar style="auto" />
+      <Text key='title' style={styles.title}>Let's stop this watch!</Text>
+      <StopWatch/>
     </View>
   );
 }
@@ -17,4 +18,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  title:{
+    marginTop: '18%',
+    fontSize: 15,
+    fontFamily: 'Courier New',
+    fontWeight: '500',
+  }
 });

--- a/App.tsx
+++ b/App.tsx
@@ -16,12 +16,12 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: '#fff',
     alignItems: 'center',
-    justifyContent: 'center',
+    justifyContent: 'center'
   },
   title:{
     marginTop: '18%',
     fontSize: 15,
     fontFamily: 'Courier New',
-    fontWeight: '500',
+    fontWeight: '500'
   }
 });

--- a/src/StopWatch.tsx
+++ b/src/StopWatch.tsx
@@ -1,8 +1,154 @@
-import { View } from 'react-native';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import React, { useState, useEffect } from 'react';
+import StopWatchButton from './StopWatchButton';
 
 export default function StopWatch() {
-  return (
-    <View >
+
+  const enum Colors{
+    gray = '#A4A4A4',
+    green = '#8A9A5B',
+    red = '#ee6b6e'
+  }
+
+  const [time, setTime] = useState(0);
+  const [isRunning, setIsRunning] = useState(false);
+  const [hasStopped, setHasStopped] = useState(false);
+  const [laps, setLaps] = useState([]);
+  
+  const minutes = Math.floor((time % 360000) / 6000);
+  const seconds = Math.floor((time % 6000) / 100);
+  const milliseconds = time % 100;
+
+  // hook that increments the timer
+  useEffect(() => {
+    let intervalId;
+    if (isRunning) {
+      intervalId = setInterval(() => setTime(time + 1), 10);
+    }
+    return () => clearInterval(intervalId);
+  }, [isRunning, time]);
+
+  const start = () => {
+    setHasStopped(false);
+    setIsRunning(true);
+  };
+
+  const stop = () => {
+    setHasStopped(true);
+    setIsRunning(false);
+  };
+
+  const reset = () => {
+    setTime(0);
+    setLaps([]);
+  };
+
+  const lap = () => {
+    setLaps(laps => [...laps, time]);
+  };
+
+  const togglePauseResume = () => {
+    setIsRunning(!isRunning);
+  };
+
+  return(
+    <View style={styles.container}>
+      <View style={styles.timerContainer}>
+        {!hasStopped && <Text style={styles.timer}>
+          {minutes.toString().padStart(2, '0')}:
+          {seconds.toString().padStart(2, '0')}:
+          {milliseconds.toString().padStart(2, '0')}
+        </Text>}
+        {hasStopped && <View style={styles.emptyTimerContainer}></View>}
+      </View>
+      <View style={styles.buttonRowContainer}>
+        <View style={styles.buttonColumnContainer} >
+          <StopWatchButton onClick={lap} disable={!isRunning} color={Colors.gray} title='Lap'/>
+          <StopWatchButton onClick={reset} color={Colors.gray} title='Reset'/>
+        </View>
+        <View style={styles.buttonColumnContainer}>
+          <StopWatchButton
+          onClick={isRunning? stop: start}
+          color={isRunning? Colors.red:Colors.green}
+          title={isRunning? "Stop":"Start"}/>
+          <StopWatchButton 
+          onClick={togglePauseResume}
+          disable={hasStopped}
+          color={Colors.gray}
+          title={isRunning? "Pause":"Resume"}/>
+        </View>
+      </View>
+      <View style={styles.lapTableView}>
+      {laps.length!=0 && <ScrollView testID="lap-list" style={styles.lapTable}>
+        {laps.map((item, index) => {
+          const minutes = Math.floor((item % 360000) / 6000);
+          const seconds = Math.floor((item % 6000) / 100);
+          const milliseconds = item % 100;
+          return(
+          <View key={index} style={styles.lapRow}>
+          <Text style={styles.lapText}>Lap {index}</Text>
+          <Text style={styles.lapTimer}>
+            {minutes.toString().padStart(2, '0')}:
+            {seconds.toString().padStart(2, '0')}:
+            {milliseconds.toString().padStart(2, '0')}</Text>
+          </View>
+          );
+          }
+        )}
+        </ScrollView>}
+      </View>
     </View>
-  );
+  )
 }
+
+const styles = StyleSheet.create({
+  timerContainer: {
+    marginTop: '10%',
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    alignItems: 'center'
+  },
+  emptyTimerContainer:{
+    height: 100,
+    width: 340,
+  },
+  timer: {
+    height: 100,
+    fontSize: 70,
+    width: 340,
+    fontFamily: 'Courier New',
+    justifyContent: 'space-between'    
+  },
+  buttonRowContainer:{
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  buttonColumnContainer:{
+    flex: 1,
+    alignItems: 'center',
+    justifyContent:'space-between'
+  },
+  lapTimer: {
+    fontSize: 18,
+    fontWeight: '400',
+    justifyContent: 'center',
+    alignItems: 'flex-start',
+    width: '23%',
+  },
+  lapText: {
+    fontSize: 18,
+    fontWeight: '500',
+    fontFamily: 'Courier New',
+  },
+  lapRow: {
+    flexDirection: 'row',
+    marginTop: '8%',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  lapTableView:{
+    height: '53%',
+    marginTop: '5%'
+  }
+})
+

--- a/src/StopWatch.tsx
+++ b/src/StopWatch.tsx
@@ -133,18 +133,18 @@ const styles = StyleSheet.create({
     fontWeight: '400',
     justifyContent: 'center',
     alignItems: 'flex-start',
-    width: '23%',
+    width: '23%'
   },
   lapText: {
     fontSize: 18,
     fontWeight: '500',
-    fontFamily: 'Courier New',
+    fontFamily: 'Courier New'
   },
   lapRow: {
     flexDirection: 'row',
     marginTop: '8%',
     justifyContent: 'space-between',
-    alignItems: 'center',
+    alignItems: 'center'
   },
   lapTableView:{
     height: '53%',

--- a/src/StopWatch.tsx
+++ b/src/StopWatch.tsx
@@ -10,11 +10,16 @@ export default function StopWatch() {
     red = '#ee6b6e'
   }
 
+  // time elapsed on stopwatch
   const [time, setTime] = useState(0);
+  // if stopwatch is currently running
   const [isRunning, setIsRunning] = useState(false);
+  // if the 'stop' button is pressed
   const [hasStopped, setHasStopped] = useState(false);
+  // an array of elapsed laps
   const [laps, setLaps] = useState([]);
-  
+
+  // elapsed time in minutes, seconds, and milliseconds
   const minutes = Math.floor((time % 360000) / 6000);
   const seconds = Math.floor((time % 6000) / 100);
   const milliseconds = time % 100;
@@ -23,78 +28,96 @@ export default function StopWatch() {
   useEffect(() => {
     let intervalId;
     if (isRunning) {
-      intervalId = setInterval(() => setTime(time + 1), 10);
+      intervalId = setInterval(() => setTime(time + 1), 10); // every 10 milliseconds
     }
     return () => clearInterval(intervalId);
   }, [isRunning, time]);
 
+  // start stopwatch
+  // currently functions the same as the resume button
   const start = () => {
     setHasStopped(false);
     setIsRunning(true);
   };
 
+  // stop stopwatch
+  // currently functions the same as the pause button, but removes the display
+  // of time on the interface
   const stop = () => {
     setHasStopped(true);
     setIsRunning(false);
   };
 
+  // clear elapsed time and laps
   const reset = () => {
     setTime(0);
     setLaps([]);
   };
 
+  //record a lap
   const lap = () => {
     setLaps(laps => [...laps, time]);
   };
 
+  // switch between pause and resume
   const togglePauseResume = () => {
     setIsRunning(!isRunning);
   };
 
+  // format time from milliseconds to minutes:seconds:centiseconds
+  const formatTime = (timeElapsed) => {
+    const minutes = Math.floor((timeElapsed % 360000) / 6000);
+    const seconds = Math.floor((timeElapsed % 6000) / 100);
+    const milliseconds = timeElapsed % 100;
+
+    const display = `${minutes.toString().padStart(2, '0')}\
+:${seconds.toString().padStart(2, '0')}\
+:${milliseconds.toString().padStart(2, '0')}`;
+    return display
+  };
+
   return(
-    <View style={styles.container}>
+    <View>
       <View style={styles.timerContainer}>
         {!hasStopped && <Text style={styles.timer}>
-          {minutes.toString().padStart(2, '0')}:
-          {seconds.toString().padStart(2, '0')}:
-          {milliseconds.toString().padStart(2, '0')}
-        </Text>}
+          {formatTime(time)}
+        </Text>
+        }
         {hasStopped && <View style={styles.emptyTimerContainer}></View>}
       </View>
+
       <View style={styles.buttonRowContainer}>
         <View style={styles.buttonColumnContainer} >
-          <StopWatchButton onClick={lap} disable={!isRunning} color={Colors.gray} title='Lap'/>
+          <StopWatchButton 
+          onClick={lap}
+          disable={!isRunning}
+          color={Colors.gray}
+          title='Lap'/>
           <StopWatchButton onClick={reset} color={Colors.gray} title='Reset'/>
         </View>
         <View style={styles.buttonColumnContainer}>
           <StopWatchButton
-          onClick={isRunning? stop: start}
-          color={isRunning? Colors.red:Colors.green}
-          title={isRunning? "Stop":"Start"}/>
+          onClick={isRunning? stop : start}
+          color={isRunning? Colors.red : Colors.green}
+          title={isRunning? "Stop" : "Start"}/>
           <StopWatchButton 
           onClick={togglePauseResume}
           disable={hasStopped}
           color={Colors.gray}
-          title={isRunning? "Pause":"Resume"}/>
+          title={isRunning? "Pause" : "Resume"}/>
         </View>
       </View>
+
       <View style={styles.lapTableView}>
-      {laps.length!=0 && <ScrollView testID="lap-list" style={styles.lapTable}>
-        {laps.map((item, index) => {
-          const minutes = Math.floor((item % 360000) / 6000);
-          const seconds = Math.floor((item % 6000) / 100);
-          const milliseconds = item % 100;
-          return(
-          <View key={index} style={styles.lapRow}>
-          <Text style={styles.lapText}>Lap {index}</Text>
-          <Text style={styles.lapTimer}>
-            {minutes.toString().padStart(2, '0')}:
-            {seconds.toString().padStart(2, '0')}:
-            {milliseconds.toString().padStart(2, '0')}</Text>
-          </View>
-          );
-          }
-        )}
+        {laps.length!=0 && <ScrollView testID="lap-list" style={styles.lapTable}>
+          {laps.map((item, index) => {
+            return(
+            <View key={index} style={styles.lapRow}>
+            <Text style={styles.lapText}>Lap {index}</Text>
+            <Text style={styles.lapTimer}>{formatTime(item)}</Text>
+            </View>
+            );}
+          )}
         </ScrollView>}
       </View>
     </View>

--- a/src/StopWatchButton.tsx
+++ b/src/StopWatchButton.tsx
@@ -29,6 +29,6 @@ const styles = StyleSheet.create({
     fontFamily: 'Courier New',
     fontWeight: 'bold',
     letterSpacing: 0.25,
-    color: 'white',
+    color: 'white'
   },
 })

--- a/src/StopWatchButton.tsx
+++ b/src/StopWatchButton.tsx
@@ -1,8 +1,32 @@
-import { View } from 'react-native';
+import React from 'react';
+import { Text, StyleSheet, TouchableOpacity } from 'react-native';
 
-export default function StopWatchButton() {
+export default function StopWatchButton(props) {
+  const { onClick, color, title } = props;
   return (
-    <View >
-    </View>
+    <TouchableOpacity
+    onPress={onClick}
+    style={[styles.button, {backgroundColor: color}]}
+    activeOpacity={0.6}>
+      <Text style={styles.text}>{title}</Text>
+    </TouchableOpacity>
   );
 }
+
+const styles = StyleSheet.create({
+  button: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 95,
+    height: 40,
+    borderRadius: 30,
+    marginTop: '5%'
+  },
+  text: {
+    fontSize: 16,
+    fontFamily: 'Courier New',
+    fontWeight: 'bold',
+    letterSpacing: 0.25,
+    color: 'white',
+  },
+})

--- a/src/StopWatchButton.tsx
+++ b/src/StopWatchButton.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { Text, StyleSheet, TouchableOpacity } from 'react-native';
 
 export default function StopWatchButton(props) {
-  const { onClick, color, title } = props;
+  const { onClick, color, title, disable } = props;
   return (
     <TouchableOpacity
     onPress={onClick}
     style={[styles.button, {backgroundColor: color}]}
-    activeOpacity={0.6}>
+    activeOpacity={0.6}
+    disabled={disable}
+    >
       <Text style={styles.text}>{title}</Text>
     </TouchableOpacity>
   );


### PR DESCRIPTION
# Description: 
Implemented StopWatch Functionality. 

### Notes on current functionality:
Currently, there is redundancy in the 'start'/'resume' and 'stop'/'pause/ buttons. The reason for this redundant implementation was to adhere to the functionality specified in the test file. 

Before the timer starts to run, both the 'Resume' and 'Lap' buttons will be disabled; they are enabled when the timer starts running. Once the timer starts, the 'start' button will operate in the same fashion as 'resume' and 'stop' will operate in the same fashion as 'pause'. The only difference between 'stop' and 'resume' is that 'stop' gets rid of the timer display, again, adhering to the specifications in the test file.

### Screenshots of interface (on an iphone 14 pro)
Interface: <img src="https://github.com/Shopify/eng-intern-assessment-react-native/assets/107783734/570f7d76-b183-449a-8ba2-36a7c8dd3783" width='200'> Pause and resume: ![RPReplay_Final1705173530-ezgif com-resize](https://github.com/Shopify/eng-intern-assessment-react-native/assets/107783734/ac6ccca5-074a-4986-bbf3-cfb17b30f768) 

Lap: ![RPReplay_Final1705173560-ezgif com-resize](https://github.com/Shopify/eng-intern-assessment-react-native/assets/107783734/6a6a2d58-0d14-43e9-a2f5-7198c7682275)         Reset: ![RPReplay_Final1705173572-ezgif com-resize](https://github.com/Shopify/eng-intern-assessment-react-native/assets/107783734/115ad5f1-3105-47e6-ad6f-05d0da63492a)

### Future improvements:
- remove redundancy (can be made similar to the iphone where there is just a start/stop button a lap/reset button)
- add line styling to the lap table to better facilitate reading