### PR TITLE
feat: daniel wagner stopwatch implementation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,4 @@
-import { StatusBar } from "expo-status-bar";
-import { StyleSheet, Text, View } from "react-native";
+import { StyleSheet, View } from "react-native";
 import StopWatch from "./src/StopWatch";
 
 export default function App() {

--- a/App.tsx
+++ b/App.tsx
@@ -1,20 +1,26 @@
-import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import { StatusBar } from "expo-status-bar";
+import { StyleSheet, Text, View } from "react-native";
+import StopWatch from "./src/StopWatch";
 
 export default function App() {
-  return (
-    <View style={styles.container}>
-      <Text>Open up App.tsx to start working on your app!</Text>
-      <StatusBar style="auto" />
-    </View>
-  );
+    return (
+        <View style={styles.container}>
+            <StopWatch />
+        </View>
+    );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
+    container: {
+        flex: 1,
+        backgroundColor: "#e0e0e0",
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    buttonContainer: {
+        flexDirection: "row",
+        alignItems: "flex-end",
+        justifyContent: "space-around",
+        width: "80%",
+    },
 });

--- a/src/StopWatch.tsx
+++ b/src/StopWatch.tsx
@@ -41,17 +41,22 @@ export default function StopWatch() {
     const referenceTimeRef = useRef<number>(0);
     const intervalRef = useRef<number | null>(null);
 
-    const handleStart = () => {
-        // Need this data to persist until restarted to show results from previous session
-        setLaps([]);
-
-        setShowResults(false);
+    const startTimer = () => {
         referenceTimeRef.current = Date.now() - time * 10;
 
         // The interval is not always going to fire exactly once every 10 ms. We can find the exact time by referencing the time when we started the time (is start or resume)
         intervalRef.current = setInterval(() => {
             setTime(Math.floor((Date.now() - referenceTimeRef.current) / 10));
         }, 10);
+    };
+
+    const handleStart = () => {
+        // Need this data to persist until restarted to show results from previous session
+        setLaps([]);
+
+        setShowResults(false);
+        startTimer();
+
         setIsTimerReset(false);
         setIsRunning(true);
     };
@@ -64,7 +69,9 @@ export default function StopWatch() {
     };
 
     const handleResume = () => {
-        handleStart();
+        startTimer();
+        setIsTimerReset(false);
+        setIsRunning(true);
     };
 
     const handleReset = () => {

--- a/src/StopWatch.tsx
+++ b/src/StopWatch.tsx
@@ -1,8 +1,165 @@
-import { View } from 'react-native';
+import { useEffect, useState } from "react";
+import {
+    Dimensions,
+    SafeAreaView,
+    ScrollView,
+    StyleSheet,
+    Text,
+    View,
+} from "react-native";
+import StopWatchButton, { ButtonTypes } from "./StopWatchButton";
+import {
+    formatTime,
+    getBestTime,
+    getWorstTime,
+    mapLapsToTimes,
+} from "./utils/time";
+import LapDisplay from "./components/Laps";
+
+// Used to ensure the app is the same width as the screen
+const { width: screenWidth } = Dimensions.get("screen");
 
 export default function StopWatch() {
-  return (
-    <View >
-    </View>
-  );
+    const [isRunning, setIsRunning] = useState<boolean>(false);
+    const [time, setTime] = useState<number>(0);
+    // Tracks when to reset the state (ie first render and when reset pressed)
+    const [isTimerReset, setIsTimerReset] = useState<boolean>(true);
+    const [laps, setLaps] = useState<{ index: number; time: number }[]>([]);
+    const [lastLapTime, setLastLapTime] = useState<number | undefined>();
+    const [worstTime, setWorstTime] = useState<number | undefined>();
+    const [bestTime, setBestTime] = useState<number | undefined>();
+
+    useEffect(() => {
+        let interval: number;
+
+        // If the stopwatch is running, set the interval with 1 second in between
+        if (isRunning) {
+            interval = setInterval(() => {
+                setTime((prevTime) => prevTime + 1);
+            }, 1000);
+        }
+
+        return () => clearInterval(interval);
+    }, [isRunning]);
+
+    const handleStart = () => {
+        setIsTimerReset(false);
+        setIsRunning(true);
+    };
+
+    const handlePause = () => {
+        setIsRunning(false);
+    };
+
+    const handleResume = () => {
+        setIsRunning(true);
+    };
+
+    const handleReset = () => {
+        setIsTimerReset(true);
+        setIsRunning(false);
+        setLaps([]);
+        setTime(0);
+        setLastLapTime(undefined);
+    };
+
+    const handleLap = () => {
+        const index = laps.length > 0 ? laps[0].index + 1 : 1;
+        const lapTime = lastLapTime ? time - lastLapTime : time;
+        const newLaps = [{ index, time: lapTime }, ...laps];
+
+        const times = mapLapsToTimes(newLaps);
+        setWorstTime(getWorstTime(times));
+        setBestTime(getBestTime(times));
+        setLaps(newLaps);
+
+        setLastLapTime(time);
+    };
+
+    return (
+        // Use safe area to avoid insets on device
+        <SafeAreaView style={{ width: screenWidth, ...styles.container }}>
+            <Text style={styles.time}>{formatTime(time)}</Text>
+            <ScrollView style={styles.lapContainer}>
+                {laps.map((lap) => {
+                    return (
+                        // Shouldn't use index, but should be fine for this simple app
+                        <LapDisplay
+                            lap={lap}
+                            bestTime={bestTime}
+                            worstTime={worstTime}
+                        />
+                    );
+                })}
+            </ScrollView>
+            <View style={styles.buttonContainer}>
+                {/* Only show start if the timer has not begun */}
+                {!isRunning && time === 0 && (
+                    <StopWatchButton
+                        type={ButtonTypes.START}
+                        onPress={handleStart}
+                    />
+                )}
+
+                {/* If the timer is going show lap, otherwise show reset */}
+                <View>
+                    {isRunning ? (
+                        <StopWatchButton
+                            type={ButtonTypes.LAP}
+                            onPress={handleLap}
+                        />
+                    ) : (
+                        !isTimerReset && (
+                            <StopWatchButton
+                                type={ButtonTypes.RESET}
+                                onPress={handleReset}
+                            />
+                        )
+                    )}
+                </View>
+
+                {/* If the timer is running, show pause, otherwise show resume */}
+                <View>
+                    {isRunning ? (
+                        <StopWatchButton
+                            type={ButtonTypes.STOP}
+                            onPress={handlePause}
+                        />
+                    ) : (
+                        !isTimerReset && (
+                            <StopWatchButton
+                                type={ButtonTypes.RESUME}
+                                onPress={handleResume}
+                            />
+                        )
+                    )}
+                </View>
+            </View>
+        </SafeAreaView>
+    );
 }
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    lapContainer: {
+        flexDirection: "column",
+        width: "100%",
+        paddingVertical: 10,
+    },
+    time: {
+        fontSize: 50,
+    },
+
+    buttonContainer: {
+        flexDirection: "row",
+        width: "100%",
+        alignContent: "center",
+        justifyContent: "center",
+        paddingVertical: 10,
+    },
+});

--- a/src/StopWatch.tsx
+++ b/src/StopWatch.tsx
@@ -77,6 +77,8 @@ export default function StopWatch() {
     const handleReset = () => {
         if (laps.length > 1) {
             setShowResults(true);
+        } else {
+            setLaps([]);
         }
         if (intervalRef.current) {
             clearInterval(intervalRef.current);

--- a/src/StopWatch.tsx
+++ b/src/StopWatch.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import {
     Dimensions,
     SafeAreaView,
@@ -15,6 +15,7 @@ import {
     mapLapsToTimes,
 } from "./utils/time";
 import LapDisplay from "./components/Laps";
+import DisplayTime from "./components/DisplayTime";
 
 // Used to ensure the app is the same width as the screen
 const { width: screenWidth } = Dimensions.get("screen");
@@ -80,7 +81,7 @@ export default function StopWatch() {
     return (
         // Use safe area to avoid insets on device
         <SafeAreaView style={{ width: screenWidth, ...styles.container }}>
-            <Text style={styles.time}>{formatTime(time)}</Text>
+            <DisplayTime time={formatTime(time)} />
             <ScrollView style={styles.lapContainer}>
                 {laps.map((lap) => {
                     return (
@@ -152,9 +153,6 @@ const styles = StyleSheet.create({
         flexDirection: "column",
         width: "100%",
         paddingVertical: 10,
-    },
-    time: {
-        fontSize: 50,
     },
 
     buttonContainer: {

--- a/src/StopWatchButton.tsx
+++ b/src/StopWatchButton.tsx
@@ -1,8 +1,67 @@
-import { View } from 'react-native';
+import { Pressable, StyleSheet, Text } from "react-native";
 
-export default function StopWatchButton() {
-  return (
-    <View >
-    </View>
-  );
+/**
+ * Types that are supported for the StopWatchButtonComponent
+ */
+export enum ButtonTypes {
+    STOP = "Stop",
+    START = "Start",
+    RESUME = "Resume",
+    LAP = "Lap",
+    RESET = "Reset",
 }
+
+interface StopWatchButtonProps {
+    type: ButtonTypes;
+    onPress: () => void;
+}
+
+/**
+ * Component that renders a button for the stopwatch
+ */
+export default function StopWatchButton({
+    type,
+    onPress,
+}: StopWatchButtonProps) {
+    const containerStyle = { ...buttonStyles[type], ...styles.container };
+    const textStyle = { ...textStyles[type], ...styles.text };
+
+    return (
+        <Pressable
+            style={{ ...containerStyle, ...styles.container }}
+            onPress={() => {
+                onPress();
+            }}
+        >
+            <Text style={textStyle}>{type}</Text>
+        </Pressable>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        marginHorizontal: 50,
+        borderRadius: 100,
+        height: 100,
+        width: 100,
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    text: { fontSize: 20, fontWeight: "bold" },
+});
+
+const buttonStyles = StyleSheet.create({
+    Start: { backgroundColor: "green" },
+    Stop: { backgroundColor: "lightcoral" },
+    Resume: { backgroundColor: "lightgreen" },
+    Lap: { backgroundColor: "gray" },
+    Reset: { backgroundColor: "red" },
+});
+
+const textStyles = StyleSheet.create({
+    Start: { color: "white" },
+    Stop: { color: "white" },
+    Resume: { color: "black" },
+    Lap: { color: "white" },
+    Reset: { color: "white" },
+});

--- a/src/components/DisplayResults.tsx
+++ b/src/components/DisplayResults.tsx
@@ -1,0 +1,55 @@
+import { StyleSheet, Text, View } from "react-native";
+import {
+    getBestTime,
+    getWorstTime,
+    getAverageTime,
+    formatTime,
+} from "../utils/time";
+
+/**
+ * Component that displays the results of the session
+ */
+export default function DisplayResults({ lapTimes }: { lapTimes: number[] }) {
+    const bestTime = getBestTime(lapTimes) || 0;
+    const worstTime = getWorstTime(lapTimes) || 0;
+    const averageTime = getAverageTime(lapTimes) || 0;
+
+    return (
+        <View style={styles.container}>
+            <View style={styles.timeContainer}>
+                <Text style={{ ...styles.title, color: "green" }}>
+                    Best Time:
+                </Text>
+                <Text style={styles.time}>{formatTime(bestTime)}</Text>
+            </View>
+            <View style={styles.timeContainer}>
+                <Text style={styles.title}>Average Time:</Text>
+                <Text style={styles.time}>{formatTime(averageTime)}</Text>
+            </View>
+            <View style={styles.timeContainer}>
+                <Text style={{ ...styles.title, color: "red" }}>
+                    Worst Time:
+                </Text>
+                <Text style={styles.time}>{formatTime(worstTime)}</Text>
+            </View>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        paddingTop: 60,
+    },
+    timeContainer: {
+        paddingVertical: 20,
+        alignSelf: "center",
+    },
+    title: {
+        fontSize: 30,
+        fontWeight: "bold",
+    },
+    time: {
+        fontSize: 20,
+        alignSelf: "center",
+    },
+});

--- a/src/components/DisplayTime.tsx
+++ b/src/components/DisplayTime.tsx
@@ -1,0 +1,40 @@
+import { StyleSheet, Text, View } from "react-native";
+
+export default function DisplayTime({ time }: { time: string }) {
+    const [minutes, seconds, milliseconds] = time.split(":");
+
+    return (
+        <View style={styles.container}>
+            <View style={styles.timeContainer}>
+                <Text style={styles.time}>{minutes}</Text>
+            </View>
+            <Text style={styles.separator}>:</Text>
+            <View style={styles.timeContainer}>
+                <Text style={styles.time}>{seconds}</Text>
+            </View>
+            <Text style={styles.separator}>:</Text>
+            <View style={styles.timeContainer}>
+                <Text style={styles.time}>{milliseconds}</Text>
+            </View>
+        </View>
+    );
+}
+const styles = StyleSheet.create({
+    container: {
+        flexDirection: "row",
+        width: "auto",
+    },
+    separator: {
+        fontSize: 50,
+    },
+    timeContainer: {
+        flexDirection: "row",
+        width: 63,
+        justifyContent: "center",
+        alignItems: "center",
+    },
+    time: {
+        fontSize: 50,
+        alignSelf: "center",
+    },
+});

--- a/src/components/DisplayTime.tsx
+++ b/src/components/DisplayTime.tsx
@@ -1,18 +1,29 @@
 import { StyleSheet, Text, View } from "react-native";
 
+/**
+ * Component that displays the time with a fixed width. Will always be the ame width
+ */
 export default function DisplayTime({ time }: { time: string }) {
+    // Want to separate out the different units to display them in their own fixed width 'boxes'
     const [minutes, seconds, milliseconds] = time.split(":");
 
     return (
         <View style={styles.container}>
+            {/* Minutes */}
             <View style={styles.timeContainer}>
                 <Text style={styles.time}>{minutes}</Text>
             </View>
+
             <Text style={styles.separator}>:</Text>
+
+            {/* Seconds */}
             <View style={styles.timeContainer}>
                 <Text style={styles.time}>{seconds}</Text>
             </View>
+
             <Text style={styles.separator}>:</Text>
+
+            {/* Milliseconds */}
             <View style={styles.timeContainer}>
                 <Text style={styles.time}>{milliseconds}</Text>
             </View>

--- a/src/components/Laps.tsx
+++ b/src/components/Laps.tsx
@@ -1,0 +1,66 @@
+import { StyleSheet, Text, View } from "react-native";
+import { formatTime } from "../utils/time";
+
+interface LapProps {
+    lap: {
+        index: number;
+        time: number;
+    };
+    bestTime?: number;
+    worstTime?: number;
+}
+
+/**
+ * Component that renders an individual lap. Includes the lap number, time, and if it was increased or decreased from the previous time
+ * @param param0
+ * @returns
+ */
+export default function LapDisplay({
+    lap: { index, time },
+    bestTime,
+    worstTime,
+}: LapProps): JSX.Element {
+    let colour = "black";
+    // In the case of a tie, we don't want to update the UI
+    if (bestTime !== worstTime) {
+        if (time === bestTime) {
+            colour = "green";
+        }
+        if (time === worstTime) {
+            colour = "red";
+        }
+    }
+    return (
+        <View
+            key={index}
+            style={{
+                ...styles.lap,
+                backgroundColor: index % 2 === 0 ? "lightblue" : "lightcyan",
+            }}
+        >
+            <Text style={{ ...styles.lapText, color: colour }}>
+                Lap {index}
+            </Text>
+            <Text style={{ ...styles.lapText, color: colour }}>
+                {formatTime(time)}
+            </Text>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    lap: {
+        flexDirection: "row",
+        width: "100%",
+        paddingHorizontal: 50,
+        height: 50,
+        alignContent: "center",
+        justifyContent: "space-between",
+    },
+    lapText: {
+        flexDirection: "column",
+        fontSize: 20,
+        height: "100%",
+        margin: "auto",
+    },
+});

--- a/src/components/Laps.tsx
+++ b/src/components/Laps.tsx
@@ -38,9 +38,18 @@ export default function LapDisplay({
                 backgroundColor: index % 2 === 0 ? "lightblue" : "lightcyan",
             }}
         >
-            <Text style={{ ...styles.lapText, color: colour }}>
-                Lap {index}
-            </Text>
+            <View style={styles.textContainer}>
+                <Text
+                    style={{
+                        ...styles.lapText,
+                        color: colour,
+                        fontWeight: "bold",
+                    }}
+                >
+                    Lap {index}
+                </Text>
+            </View>
+
             <Text style={{ ...styles.lapText, color: colour }}>
                 {formatTime(time)}
             </Text>
@@ -57,10 +66,17 @@ const styles = StyleSheet.create({
         alignContent: "center",
         justifyContent: "space-between",
     },
+    textContainer: {
+        justifyContent: "center",
+        alignContent: "center",
+        alignItems: "center",
+        alignSelf: "center",
+    },
     lapText: {
         flexDirection: "column",
         fontSize: 20,
         height: "100%",
         margin: "auto",
+        alignSelf: "center",
     },
 });

--- a/src/components/Laps.tsx
+++ b/src/components/Laps.tsx
@@ -12,8 +12,6 @@ interface LapProps {
 
 /**
  * Component that renders an individual lap. Includes the lap number, time, and if it was increased or decreased from the previous time
- * @param param0
- * @returns
  */
 export default function LapDisplay({
     lap: { index, time },
@@ -23,16 +21,18 @@ export default function LapDisplay({
     let colour = "black";
     // In the case of a tie, we don't want to update the UI
     if (bestTime !== worstTime) {
+        // Best times will be displayed in green
         if (time === bestTime) {
             colour = "green";
         }
+        // Worst times in red
         if (time === worstTime) {
             colour = "red";
         }
     }
     return (
         <View
-            key={index}
+            // Alternating background colour to make it easier to read
             style={{
                 ...styles.lap,
                 backgroundColor: index % 2 === 0 ? "lightblue" : "lightcyan",

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,24 +1,24 @@
 /**
  * Formats a number of seconds to be displayed for the stopwatch.
- * @param seconds The number of seconds to be formatted and displayed
- * @returns A formatted time as a string with hours, minutes, and seconds
+ * @param milliseconds The number of milliseconds to be formatted and displayed
+ * @returns A formatted time as a string with minutes, seconds, and milliseconds
  */
-export const formatTime = (seconds: number) => {
-    // 3600 seconds in hour
-    const hours = Math.floor(seconds / 3600);
-    // Get remainder after hour get, 60 seconds in 1 min
-    const minutes = Math.floor((seconds % 3600) / 60);
-    // Leftover will be the remaining seconds
-    const remainingSeconds = seconds % 60;
-    return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(
+export const formatTime = (milliseconds: number) => {
+    // 6000 milliseconds in 1 minute
+    const minutes = Math.floor(milliseconds / 6000);
+    // Get remainder after minutes, 100 milliseconds in 1 second
+    const seconds = Math.floor((milliseconds % 6000) / 100);
+    // Leftover will be the remaining milliseconds
+    const remainingMilliseconds = milliseconds % 100;
+    return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(
         2,
         "0"
-    )}:${String(remainingSeconds).padStart(2, "0")}`;
+    )}:${String(remainingMilliseconds).padStart(2, "0").slice(0, 2)}`;
 };
 
 /**
  * Returns the worst time (ie the highest time)
- * @param times list of times in seconds
+ * @param times list of times in milliseconds
  * @returns the  worst time
  */
 export const getWorstTime = (times: number[]): number | undefined => {
@@ -30,7 +30,7 @@ export const getWorstTime = (times: number[]): number | undefined => {
 
 /**
  * Returns the best time (ie the lowest time)
- * @param times list of times in seconds
+ * @param times list of times in milliseconds
  * @returns the best time
  */
 export const getBestTime = (times: number[]): number | undefined => {

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -41,6 +41,24 @@ export const getBestTime = (times: number[]): number | undefined => {
 };
 
 /**
+ * Returns the average time for a list of times.
+ * @param times list of times in milliseconds
+ * @returns the average time
+ */
+export const getAverageTime = (times: number[]): number | undefined => {
+    if (times.length < 1) {
+        return;
+    }
+    // Calculate the sum of all numbers in the array
+    const sum = times.reduce((acc, num) => acc + num, 0);
+
+    // Calculate the average
+    const average = sum / times.length;
+
+    return average;
+};
+
+/**
  * Maps laps objects to an array of number of their corresponding times
  * @param laps List of lap objects
  * @returns List of times as numbers

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,56 @@
+/**
+ * Formats a number of seconds to be displayed for the stopwatch.
+ * @param seconds The number of seconds to be formatted and displayed
+ * @returns A formatted time as a string with hours, minutes, and seconds
+ */
+export const formatTime = (seconds: number) => {
+    // 3600 seconds in hour
+    const hours = Math.floor(seconds / 3600);
+    // Get remainder after hour get, 60 seconds in 1 min
+    const minutes = Math.floor((seconds % 3600) / 60);
+    // Leftover will be the remaining seconds
+    const remainingSeconds = seconds % 60;
+    return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(
+        2,
+        "0"
+    )}:${String(remainingSeconds).padStart(2, "0")}`;
+};
+
+/**
+ * Returns the worst time (ie the highest time)
+ * @param times list of times in seconds
+ * @returns the  worst time
+ */
+export const getWorstTime = (times: number[]): number | undefined => {
+    if (times.length < 1) {
+        return;
+    }
+    return Math.max(...times);
+};
+
+/**
+ * Returns the best time (ie the lowest time)
+ * @param times list of times in seconds
+ * @returns the best time
+ */
+export const getBestTime = (times: number[]): number | undefined => {
+    if (times.length < 1) {
+        return;
+    }
+    return Math.min(...times);
+};
+
+/**
+ * Maps laps objects to an array of number of their corresponding times
+ * @param laps List of lap objects
+ * @returns List of times as numbers
+ */
+export const mapLapsToTimes = (
+    laps: { time: number; index: number }[]
+): number[] => {
+    if (laps.length < 1) {
+        return [];
+    }
+    const times = laps.map((lap) => lap.time);
+    return times;
+};


### PR DESCRIPTION
This stopwatch implementation accurately keeps track of time down to the millisecond. Has the ability to start, stop, resume, reset, and lap. 

Laps are kept on screen in a scrollable view to allow the user to see their results regardless of how long they are using the app or their device is. Additionally, the list of laps shows the user their best times, marked in green, and their worst times, marked in red.

When they reset the stopwatch, a summary is shown that displays their best lap time, worst lap time, and average lap time. 

Start screen:
<img src="https://github.com/Shopify/eng-intern-assessment-react-native/assets/58407467/434cb9ec-7fff-40a4-8187-4308e59bfaf5" width=300/>

Lap List:
<img src="https://github.com/Shopify/eng-intern-assessment-react-native/assets/58407467/20e38232-d5e1-4836-a8eb-560735202b16" width=300/>

Summary Screen:
<img src="https://github.com/Shopify/eng-intern-assessment-react-native/assets/58407467/3c78b347-961c-4eb6-8ec5-33a3801f22e5" width=300/>

Resume/Reset:
<img src="https://github.com/Shopify/eng-intern-assessment-react-native/assets/58407467/41607440-294b-4c9f-a5ab-096fd09de7f2" width=300/>

