### PR TITLE
Stopwatch feature made by Lucas Berger

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,6 +16,6 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: "#fff",
     alignItems: "stretch",
-    justifyContent: "center",
+    paddingTop: 100,
   },
 });

--- a/App.tsx
+++ b/App.tsx
@@ -5,7 +5,6 @@ import StopWatch from "./src/StopWatch";
 export default function App() {
   return (
     <View style={styles.container}>
-      <Text>Stopwatch:</Text>
       <StopWatch />
       <StatusBar style="auto" />
     </View>
@@ -16,7 +15,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: "#fff",
-    alignItems: "center",
+    alignItems: "stretch",
     justifyContent: "center",
   },
 });

--- a/App.tsx
+++ b/App.tsx
@@ -1,10 +1,12 @@
-import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import { StatusBar } from "expo-status-bar";
+import { StyleSheet, Text, View } from "react-native";
+import StopWatch from "./src/StopWatch";
 
 export default function App() {
   return (
     <View style={styles.container}>
-      <Text>Open up App.tsx to start working on your app!</Text>
+      <Text>Stopwatch:</Text>
+      <StopWatch />
       <StatusBar style="auto" />
     </View>
   );
@@ -13,8 +15,8 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
+    backgroundColor: "#fff",
+    alignItems: "center",
+    justifyContent: "center",
   },
 });

--- a/src/StopWatch.tsx
+++ b/src/StopWatch.tsx
@@ -1,8 +1,28 @@
-import { View } from 'react-native';
+import { useEffect, useState } from "react";
+import { Text, View } from "react-native";
+
+const getCurrentTimeMs = () => {
+  return Date.now() / 100_000_000_000_000;
+};
 
 export default function StopWatch() {
+  const [timeMs, setTimeMs] = useState(0);
+  const [lastTimeMs, setLastTimeMs] = useState(0);
+
+  useEffect(() => {
+    setLastTimeMs(getCurrentTimeMs());
+    const interval = setInterval(() => {
+      const newTimeMs = getCurrentTimeMs();
+      const diff = newTimeMs - lastTimeMs;
+      setTimeMs((time) => time + diff);
+      setLastTimeMs(newTimeMs);
+    }, 1);
+    return () => clearInterval(interval);
+  }, []);
+
   return (
-    <View >
+    <View>
+      <Text>{timeMs.toFixed(3)}s</Text>
     </View>
   );
 }

--- a/src/StopWatch.tsx
+++ b/src/StopWatch.tsx
@@ -46,7 +46,7 @@ const styles = StyleSheet.create({
 export default function StopWatch() {
   // counting funcionality
   const [timeMs, setTimeMs] = useState(0);
-  const [lastTimeMs, setLastTimeMs] = useState<number | null>(null);
+  const lastTimeMs = useRef<number | null>(null);
 
   const frameId = useRef<number | null>(null);
 
@@ -56,23 +56,24 @@ export default function StopWatch() {
   useEffect(() => {
     const tick = (time: number) => {
       const currentTime = time / 1000;
-      if (lastTimeMs === null) {
-        setLastTimeMs(currentTime);
+      if (lastTimeMs.current === null) {
+        lastTimeMs.current = currentTime;
+        frameId.current = requestAnimationFrame(tick);
         return;
       }
-      const diff = currentTime - lastTimeMs;
+      const diff = currentTime - lastTimeMs.current;
       if (isRunning) {
-        setTimeMs(timeMs + diff);
+        setTimeMs((time) => time + diff);
       }
 
-      setLastTimeMs(currentTime);
+      lastTimeMs.current = currentTime;
 
       frameId.current = requestAnimationFrame(tick);
     };
 
     frameId.current = requestAnimationFrame(tick);
     return () => {
-      setLastTimeMs(null);
+      lastTimeMs.current = null;
       if (frameId.current) {
         cancelAnimationFrame(frameId.current);
       }
@@ -123,7 +124,7 @@ export default function StopWatch() {
             <View style={styles.lapText}>
               <Text style={styles.cellLeft}>Round</Text>
               <Text style={styles.cellRight}>Time Recorded</Text>
-              <Text style={styles.cellRight}>Difference</Text>
+              <Text style={styles.cellRight}>Duration</Text>
             </View>
           )}
           renderItem={({ item, index }) => (

--- a/src/StopWatch.tsx
+++ b/src/StopWatch.tsx
@@ -8,6 +8,10 @@ const styles = StyleSheet.create({
   stopWatchContainer: {
     alignItems: "center",
   },
+  lapText: {
+    flexDirection: "row",
+    gap: 10,
+  },
 });
 
 const getCurrentTime = () => {
@@ -35,6 +39,15 @@ export default function StopWatch() {
     return () => clearInterval(interval);
   }, [isRunning]);
 
+  // laps
+  const [laps, setLaps] = useState<number[]>([]);
+  const lapDiff = useMemo(() => {
+    return laps.map(
+      (cur, index, arr) => (index != 0 ? cur - arr[index - 1] : cur),
+      [],
+    );
+  }, [laps]);
+
   // display
   const displayTimeMs = useMemo(() => timeMs.toFixed(3), [timeMs]);
 
@@ -42,16 +55,29 @@ export default function StopWatch() {
     <View style={styles.stopWatchContainer}>
       <Text>{displayTimeMs}s</Text>
       <View style={styles.buttonContainer}>
-        <Button
-          title="Reset"
-          disabled={isRunning}
-          onPress={() => setTimeMs(0)}
-        />
+        {isRunning ? (
+          <Button title="Lap" onPress={() => setLaps([...laps, timeMs])} />
+        ) : (
+          <Button
+            title="Reset"
+            disabled={isRunning}
+            onPress={() => setTimeMs(0)}
+          />
+        )}
         {isRunning ? (
           <Button title="Stop" onPress={() => setIsRunning(false)} />
         ) : (
           <Button title="Start" onPress={() => setIsRunning(true)} />
         )}
+      </View>
+      <View>
+        {laps.map((lap, index) => (
+          <View key={index} style={styles.lapText}>
+            <Text>{index}</Text>
+            <Text>{lap.toFixed(3)}</Text>
+            <Text>{lapDiff[index].toFixed(3)}</Text>
+          </View>
+        ))}
       </View>
     </View>
   );

--- a/src/StopWatch.tsx
+++ b/src/StopWatch.tsx
@@ -25,19 +25,18 @@ export default function StopWatch() {
   const [isRunning, setIsRunning] = useState(false);
 
   useEffect(() => {
-    setLastTimeMs(Date.now());
-
     const tick = (time: number) => {
       const currentTime = time / 1000;
-      setLastTimeMs(currentTime);
-
       if (lastTimeMs === null) {
+        setLastTimeMs(currentTime);
         return;
       }
       const diff = currentTime - lastTimeMs;
       if (isRunning) {
         setTimeMs(timeMs + diff);
       }
+
+      setLastTimeMs(currentTime);
 
       frameId.current = requestAnimationFrame(tick);
     };

--- a/src/StopWatch.tsx
+++ b/src/StopWatch.tsx
@@ -1,5 +1,14 @@
 import { useEffect, useMemo, useState } from "react";
-import { Button, Text, View } from "react-native";
+import { Button, StyleSheet, Text, View } from "react-native";
+
+const styles = StyleSheet.create({
+  buttonContainer: {
+    flexDirection: "row",
+  },
+  stopWatchContainer: {
+    alignItems: "center",
+  },
+});
 
 const getCurrentTime = () => {
   return Date.now() / 1000;
@@ -15,7 +24,6 @@ export default function StopWatch() {
 
   useEffect(() => {
     setLastTimeMs(getCurrentTime());
-    console.log("isRunning", isRunning);
     const interval = setInterval(() => {
       const newTimeMs = getCurrentTime();
       const diff = newTimeMs - lastTimeMs;
@@ -31,13 +39,20 @@ export default function StopWatch() {
   const displayTimeMs = useMemo(() => timeMs.toFixed(3), [timeMs]);
 
   return (
-    <View>
+    <View style={styles.stopWatchContainer}>
       <Text>{displayTimeMs}s</Text>
-      {isRunning ? (
-        <Button title="Stop" onPress={() => setIsRunning(false)} />
-      ) : (
-        <Button title="Start" onPress={() => setIsRunning(true)} />
-      )}
+      <View style={styles.buttonContainer}>
+        <Button
+          title="Reset"
+          disabled={isRunning}
+          onPress={() => setTimeMs(0)}
+        />
+        {isRunning ? (
+          <Button title="Stop" onPress={() => setIsRunning(false)} />
+        ) : (
+          <Button title="Start" onPress={() => setIsRunning(true)} />
+        )}
+      </View>
     </View>
   );
 }

--- a/src/StopWatch.tsx
+++ b/src/StopWatch.tsx
@@ -61,7 +61,10 @@ export default function StopWatch() {
           <Button
             title="Reset"
             disabled={isRunning}
-            onPress={() => setTimeMs(0)}
+            onPress={() => {
+              setLaps([]);
+              setTimeMs(0);
+            }}
           />
         )}
         {isRunning ? (
@@ -73,7 +76,7 @@ export default function StopWatch() {
       <View>
         {laps.map((lap, index) => (
           <View key={index} style={styles.lapText}>
-            <Text>{index}</Text>
+            <Text>{index + 1}</Text>
             <Text>{lap.toFixed(3)}</Text>
             <Text>{lapDiff[index].toFixed(3)}</Text>
           </View>

--- a/src/StopWatch.tsx
+++ b/src/StopWatch.tsx
@@ -7,6 +7,7 @@ import {
   View,
   ViewStyle,
 } from "react-native";
+import StopWatchButton from "./StopWatchButton";
 
 const styles = StyleSheet.create({
   buttonContainer: {
@@ -95,11 +96,13 @@ export default function StopWatch() {
       <Text style={styles.timeCounter}>{displayTimeMs}s</Text>
       <View style={styles.buttonContainer}>
         {isRunning ? (
-          <Button title="Lap" onPress={() => setLaps([...laps, timeMs])} />
+          <StopWatchButton
+            type="lap"
+            onPress={() => setLaps([...laps, timeMs])}
+          />
         ) : (
-          <Button
-            title="Reset"
-            disabled={isRunning}
+          <StopWatchButton
+            type="reset"
             onPress={() => {
               setLaps([]);
               setTimeMs(0);
@@ -107,16 +110,16 @@ export default function StopWatch() {
           />
         )}
         {isRunning ? (
-          <Button title="Stop" onPress={() => setIsRunning(false)} />
+          <StopWatchButton type="stop" onPress={() => setIsRunning(false)} />
         ) : (
-          <Button title="Start" onPress={() => setIsRunning(true)} />
+          <StopWatchButton type="start" onPress={() => setIsRunning(true)} />
         )}
       </View>
       <View style={styles.lapList}>
         <FlatList
           data={laps}
           style={styles.lapList}
-          StickyHeaderComponent={() => (
+          ListHeaderComponent={() => (
             <View style={styles.lapText}>
               <Text style={styles.cellLeft}>Round</Text>
               <Text style={styles.cellRight}>Time Recorded</Text>

--- a/src/StopWatch.tsx
+++ b/src/StopWatch.tsx
@@ -1,11 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import {
-  FlatList,
-  StyleSheet,
-  Text,
-  View,
-} from "react-native";
+import { FlatList, StyleSheet, Text, View } from "react-native";
 import StopWatchButton from "./StopWatchButton";
+import { formatTime } from "./util/time";
 
 const styles = StyleSheet.create({
   buttonContainer: {
@@ -21,18 +17,12 @@ const styles = StyleSheet.create({
     fontWeight: "bold",
   },
   lapList: {
-    height: 300,
     width: "100%",
   },
   lapText: {
     flexDirection: "row",
     gap: 10,
     alignSelf: "stretch",
-  },
-  cellLeft: {
-    flexGrow: 1,
-    fontSize: 20,
-    textAlign: "left",
   },
   cellRight: {
     flexGrow: 1,
@@ -94,10 +84,7 @@ export default function StopWatch() {
   }, [laps]);
 
   // display
-  const displaytime = useMemo(() => {
-    const format = (x: number) => String(x.toFixed(0)).padStart(2, "0");
-    return `${format(time / 3600)}:${format((time / 60) % 60)}:${format(time % 60)}`;
-  }, [time]);
+  const displaytime = useMemo(() => formatTime(time), [time]);
 
   return (
     <View style={styles.stopWatchContainer}>
@@ -106,13 +93,10 @@ export default function StopWatch() {
       )}
       <View style={styles.buttonContainer}>
         {state === "running" && (
-          <>
-            <StopWatchButton
-              type="lap"
-              onPress={() => setLaps([...laps, time])}
-            />
-            <StopWatchButton type="pause" onPress={() => setState("paused")} />
-          </>
+          <StopWatchButton
+            type="lap"
+            onPress={() => setLaps([...laps, time])}
+          />
         )}
         <StopWatchButton
           type="reset"
@@ -126,32 +110,22 @@ export default function StopWatch() {
           (state == "running" && (
             <StopWatchButton type="stop" onPress={() => setState("stopped")} />
           ))}
-        {state == "initial" && (
+
+        {state == "initial" ? (
           <StopWatchButton type="start" onPress={() => setState("running")} />
-        )}
+        ) : state == "running" ? (
+          <StopWatchButton type="pause" onPress={() => setState("paused")} />
+        ) : state == "paused" ? (
+          <StopWatchButton type="resume" onPress={() => setState("running")} />
+        ) : null}
       </View>
-      {laps.length === 0 ? null : (
+      {lapDiff.length === 0 ? null : (
         <View testID="lap-list" style={styles.lapList}>
-          <FlatList
-            data={laps}
-            style={styles.lapList}
-            ListHeaderComponent={() => (
-              <View style={styles.lapText}>
-                <Text style={styles.cellLeft}>Round</Text>
-                <Text style={styles.cellRight}>Time Recorded</Text>
-                <Text style={styles.cellRight}>Duration</Text>
-              </View>
-            )}
-            renderItem={({ item, index }) => (
-              <View key={index} style={styles.lapText}>
-                <Text style={styles.cellLeft}>Round {index + 1}</Text>
-                <Text style={styles.cellRight}>{item.toFixed(3)}s</Text>
-                <Text style={styles.cellRight}>
-                  {lapDiff[index].toFixed(3)}s
-                </Text>
-              </View>
-            )}
-          />
+          {lapDiff.map((time, index) => (
+            <Text key={index} style={styles.cellRight}>
+              {formatTime(time)}
+            </Text>
+          ))}
         </View>
       )}
     </View>

--- a/src/StopWatch.tsx
+++ b/src/StopWatch.tsx
@@ -45,8 +45,8 @@ const styles = StyleSheet.create({
 
 export default function StopWatch() {
   // counting funcionality
-  const [timeMs, setTimeMs] = useState(0);
-  const lastTimeMs = useRef<number | null>(null);
+  const [time, setTime] = useState(0);
+  const lastTime = useRef<number | null>(null);
 
   const frameId = useRef<number | null>(null);
 
@@ -58,17 +58,17 @@ export default function StopWatch() {
       const currentTime = time / 1000;
 
       // get current time on first walkthrough
-      if (lastTimeMs.current === null) {
-        lastTimeMs.current = currentTime;
+      if (lastTime.current === null) {
+        lastTime.current = currentTime;
         frameId.current = requestAnimationFrame(tick);
         return;
       }
-      const diff = currentTime - lastTimeMs.current;
+      const diff = currentTime - lastTime.current;
       if (isRunning) {
-        setTimeMs((time) => time + diff);
+        setTime((time) => time + diff);
       }
 
-      lastTimeMs.current = currentTime;
+      lastTime.current = currentTime;
 
       // request next frame
       frameId.current = requestAnimationFrame(tick);
@@ -77,7 +77,7 @@ export default function StopWatch() {
     frameId.current = requestAnimationFrame(tick);
     return () => {
       // reset last time state
-      lastTimeMs.current = null;
+      lastTime.current = null;
       if (frameId.current) {
         cancelAnimationFrame(frameId.current);
       }
@@ -94,23 +94,26 @@ export default function StopWatch() {
   }, [laps]);
 
   // display
-  const displayTimeMs = useMemo(() => timeMs.toFixed(3), [timeMs]);
+  const displaytime = useMemo(() => {
+    const format = (x: number) => String(x.toFixed(0)).padStart(2, "0");
+    return `${format(time / 3600)}:${format((time / 60) % 60)}:${format(time % 60)}`;
+  }, [time]);
 
   return (
     <View style={styles.stopWatchContainer}>
-      <Text style={styles.timeCounter}>{displayTimeMs}s</Text>
+      <Text style={styles.timeCounter}>{displaytime}</Text>
       <View style={styles.buttonContainer}>
         {isRunning ? (
           <StopWatchButton
             type="lap"
-            onPress={() => setLaps([...laps, timeMs])}
+            onPress={() => setLaps([...laps, time])}
           />
         ) : (
           <StopWatchButton
             type="reset"
             onPress={() => {
               setLaps([]);
-              setTimeMs(0);
+              setTime(0);
             }}
           />
         )}
@@ -120,26 +123,30 @@ export default function StopWatch() {
           <StopWatchButton type="start" onPress={() => setIsRunning(true)} />
         )}
       </View>
-      <View style={styles.lapList}>
-        <FlatList
-          data={laps}
-          style={styles.lapList}
-          ListHeaderComponent={() => (
-            <View style={styles.lapText}>
-              <Text style={styles.cellLeft}>Round</Text>
-              <Text style={styles.cellRight}>Time Recorded</Text>
-              <Text style={styles.cellRight}>Duration</Text>
-            </View>
-          )}
-          renderItem={({ item, index }) => (
-            <View key={index} style={styles.lapText}>
-              <Text style={styles.cellLeft}>Round {index + 1}</Text>
-              <Text style={styles.cellRight}>{item.toFixed(3)}s</Text>
-              <Text style={styles.cellRight}>{lapDiff[index].toFixed(3)}s</Text>
-            </View>
-          )}
-        />
-      </View>
+      {laps.length === 0 ? null : (
+        <View testID="lap-list" style={styles.lapList}>
+          <FlatList
+            data={laps}
+            style={styles.lapList}
+            ListHeaderComponent={() => (
+              <View style={styles.lapText}>
+                <Text style={styles.cellLeft}>Round</Text>
+                <Text style={styles.cellRight}>Time Recorded</Text>
+                <Text style={styles.cellRight}>Duration</Text>
+              </View>
+            )}
+            renderItem={({ item, index }) => (
+              <View key={index} style={styles.lapText}>
+                <Text style={styles.cellLeft}>Round {index + 1}</Text>
+                <Text style={styles.cellRight}>{item.toFixed(3)}s</Text>
+                <Text style={styles.cellRight}>
+                  {lapDiff[index].toFixed(3)}s
+                </Text>
+              </View>
+            )}
+          />
+        </View>
+      )}
     </View>
   );
 }

--- a/src/StopWatch.tsx
+++ b/src/StopWatch.tsx
@@ -1,28 +1,43 @@
-import { useEffect, useState } from "react";
-import { Text, View } from "react-native";
+import { useEffect, useMemo, useState } from "react";
+import { Button, Text, View } from "react-native";
 
-const getCurrentTimeMs = () => {
-  return Date.now() / 100_000_000_000_000;
+const getCurrentTime = () => {
+  return Date.now() / 1000;
 };
 
 export default function StopWatch() {
+  // counting funcionality
   const [timeMs, setTimeMs] = useState(0);
   const [lastTimeMs, setLastTimeMs] = useState(0);
 
+  // start/stop funcitonality
+  const [isRunning, setIsRunning] = useState(false);
+
   useEffect(() => {
-    setLastTimeMs(getCurrentTimeMs());
+    setLastTimeMs(getCurrentTime());
+    console.log("isRunning", isRunning);
     const interval = setInterval(() => {
-      const newTimeMs = getCurrentTimeMs();
+      const newTimeMs = getCurrentTime();
       const diff = newTimeMs - lastTimeMs;
-      setTimeMs((time) => time + diff);
+      if (isRunning) {
+        setTimeMs(timeMs + diff);
+      }
       setLastTimeMs(newTimeMs);
     }, 1);
     return () => clearInterval(interval);
-  }, []);
+  }, [isRunning]);
+
+  // display
+  const displayTimeMs = useMemo(() => timeMs.toFixed(3), [timeMs]);
 
   return (
     <View>
-      <Text>{timeMs.toFixed(3)}s</Text>
+      <Text>{displayTimeMs}s</Text>
+      {isRunning ? (
+        <Button title="Stop" onPress={() => setIsRunning(false)} />
+      ) : (
+        <Button title="Start" onPress={() => setIsRunning(true)} />
+      )}
     </View>
   );
 }

--- a/src/StopWatch.tsx
+++ b/src/StopWatch.tsx
@@ -56,6 +56,8 @@ export default function StopWatch() {
   useEffect(() => {
     const tick = (time: number) => {
       const currentTime = time / 1000;
+
+      // get current time on first walkthrough
       if (lastTimeMs.current === null) {
         lastTimeMs.current = currentTime;
         frameId.current = requestAnimationFrame(tick);
@@ -68,11 +70,13 @@ export default function StopWatch() {
 
       lastTimeMs.current = currentTime;
 
+      // request next frame
       frameId.current = requestAnimationFrame(tick);
     };
 
     frameId.current = requestAnimationFrame(tick);
     return () => {
+      // reset last time state
       lastTimeMs.current = null;
       if (frameId.current) {
         cancelAnimationFrame(frameId.current);

--- a/src/StopWatch.tsx
+++ b/src/StopWatch.tsx
@@ -1,16 +1,44 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Button, StyleSheet, Text, View } from "react-native";
+import {
+  Button,
+  FlatList,
+  StyleSheet,
+  Text,
+  View,
+  ViewStyle,
+} from "react-native";
 
 const styles = StyleSheet.create({
   buttonContainer: {
     flexDirection: "row",
+    gap: 10,
   },
   stopWatchContainer: {
     alignItems: "center",
+    gap: 10,
+  },
+  timeCounter: {
+    fontSize: 50,
+    fontWeight: "bold",
+  },
+  lapList: {
+    height: 300,
+    width: "100%",
   },
   lapText: {
     flexDirection: "row",
     gap: 10,
+    alignSelf: "stretch",
+  },
+  cellLeft: {
+    flexGrow: 1,
+    fontSize: 20,
+    textAlign: "left",
+  },
+  cellRight: {
+    flexGrow: 1,
+    fontSize: 20,
+    textAlign: "right",
   },
 });
 
@@ -64,7 +92,7 @@ export default function StopWatch() {
 
   return (
     <View style={styles.stopWatchContainer}>
-      <Text>{displayTimeMs}s</Text>
+      <Text style={styles.timeCounter}>{displayTimeMs}s</Text>
       <View style={styles.buttonContainer}>
         {isRunning ? (
           <Button title="Lap" onPress={() => setLaps([...laps, timeMs])} />
@@ -84,14 +112,25 @@ export default function StopWatch() {
           <Button title="Start" onPress={() => setIsRunning(true)} />
         )}
       </View>
-      <View>
-        {laps.map((lap, index) => (
-          <View key={index} style={styles.lapText}>
-            <Text>{index + 1}</Text>
-            <Text>{lap.toFixed(3)}</Text>
-            <Text>{lapDiff[index].toFixed(3)}</Text>
-          </View>
-        ))}
+      <View style={styles.lapList}>
+        <FlatList
+          data={laps}
+          style={styles.lapList}
+          StickyHeaderComponent={() => (
+            <View style={styles.lapText}>
+              <Text style={styles.cellLeft}>Round</Text>
+              <Text style={styles.cellRight}>Time Recorded</Text>
+              <Text style={styles.cellRight}>Difference</Text>
+            </View>
+          )}
+          renderItem={({ item, index }) => (
+            <View key={index} style={styles.lapText}>
+              <Text style={styles.cellLeft}>Round {index + 1}</Text>
+              <Text style={styles.cellRight}>{item.toFixed(3)}</Text>
+              <Text style={styles.cellRight}>{lapDiff[index].toFixed(3)}</Text>
+            </View>
+          )}
+        />
       </View>
     </View>
   );

--- a/src/StopWatch.tsx
+++ b/src/StopWatch.tsx
@@ -129,8 +129,8 @@ export default function StopWatch() {
           renderItem={({ item, index }) => (
             <View key={index} style={styles.lapText}>
               <Text style={styles.cellLeft}>Round {index + 1}</Text>
-              <Text style={styles.cellRight}>{item.toFixed(3)}</Text>
-              <Text style={styles.cellRight}>{lapDiff[index].toFixed(3)}</Text>
+              <Text style={styles.cellRight}>{item.toFixed(3)}s</Text>
+              <Text style={styles.cellRight}>{lapDiff[index].toFixed(3)}s</Text>
             </View>
           )}
         />

--- a/src/StopWatch.tsx
+++ b/src/StopWatch.tsx
@@ -1,11 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
-  Button,
   FlatList,
   StyleSheet,
   Text,
   View,
-  ViewStyle,
 } from "react-native";
 import StopWatchButton from "./StopWatchButton";
 
@@ -43,6 +41,8 @@ const styles = StyleSheet.create({
   },
 });
 
+type StopWatchStates = "initial" | "running" | "stopped" | "paused";
+
 export default function StopWatch() {
   // counting funcionality
   const [time, setTime] = useState(0);
@@ -50,8 +50,8 @@ export default function StopWatch() {
 
   const frameId = useRef<number | null>(null);
 
-  // start/stop funcitonality
-  const [isRunning, setIsRunning] = useState(false);
+  // start/pause/stop funcitonality
+  const [state, setState] = useState<StopWatchStates>("initial");
 
   useEffect(() => {
     const tick = (time: number) => {
@@ -64,7 +64,7 @@ export default function StopWatch() {
         return;
       }
       const diff = currentTime - lastTime.current;
-      if (isRunning) {
+      if (state == "running") {
         setTime((time) => time + diff);
       }
 
@@ -82,7 +82,7 @@ export default function StopWatch() {
         cancelAnimationFrame(frameId.current);
       }
     };
-  }, [isRunning]);
+  }, [state]);
 
   // laps
   const [laps, setLaps] = useState<number[]>([]);
@@ -101,26 +101,33 @@ export default function StopWatch() {
 
   return (
     <View style={styles.stopWatchContainer}>
-      <Text style={styles.timeCounter}>{displaytime}</Text>
+      {state !== "stopped" && (
+        <Text style={styles.timeCounter}>{displaytime}</Text>
+      )}
       <View style={styles.buttonContainer}>
-        {isRunning ? (
-          <StopWatchButton
-            type="lap"
-            onPress={() => setLaps([...laps, time])}
-          />
-        ) : (
-          <StopWatchButton
-            type="reset"
-            onPress={() => {
-              setLaps([]);
-              setTime(0);
-            }}
-          />
+        {state === "running" && (
+          <>
+            <StopWatchButton
+              type="lap"
+              onPress={() => setLaps([...laps, time])}
+            />
+            <StopWatchButton type="pause" onPress={() => setState("paused")} />
+          </>
         )}
-        {isRunning ? (
-          <StopWatchButton type="stop" onPress={() => setIsRunning(false)} />
-        ) : (
-          <StopWatchButton type="start" onPress={() => setIsRunning(true)} />
+        <StopWatchButton
+          type="reset"
+          onPress={() => {
+            setState("initial");
+            setLaps([]);
+            setTime(0);
+          }}
+        />
+        {state == "paused" ||
+          (state == "running" && (
+            <StopWatchButton type="stop" onPress={() => setState("stopped")} />
+          ))}
+        {state == "initial" && (
+          <StopWatchButton type="start" onPress={() => setState("running")} />
         )}
       </View>
       {laps.length === 0 ? null : (

--- a/src/StopWatchButton.tsx
+++ b/src/StopWatchButton.tsx
@@ -1,8 +1,31 @@
-import { View } from 'react-native';
+import { Button, ButtonProps, View, ViewStyle } from "react-native";
 
-export default function StopWatchButton() {
-  return (
-    <View >
-    </View>
-  );
+type StopWatchButtonTypes = "start" | "stop" | "lap" | "reset";
+
+const buttonProps: { [type in StopWatchButtonTypes]: ButtonProps } = {
+  start: {
+    title: "Start",
+    color: "green",
+  },
+  lap: {
+    title: "Lap",
+    color: "blue",
+  },
+  stop: {
+    title: "Stop",
+    color: "red",
+  },
+  reset: {
+    title: "Reset",
+    color: "black",
+  },
+};
+
+type StopWatchButtonProps = {
+  onPress?: () => void;
+  type: StopWatchButtonTypes;
+};
+
+export default function StopWatchButton(props: StopWatchButtonProps) {
+  return <Button {...buttonProps[props.type]} onPress={props.onPress} />;
 }

--- a/src/StopWatchButton.tsx
+++ b/src/StopWatchButton.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonProps, View, ViewStyle } from "react-native";
 
-type StopWatchButtonTypes = "start" | "stop" | "lap" | "reset";
+type StopWatchButtonTypes = "start" | "stop" | "lap" | "reset" | "pause";
 
 const buttonProps: { [type in StopWatchButtonTypes]: ButtonProps } = {
   start: {
@@ -18,6 +18,10 @@ const buttonProps: { [type in StopWatchButtonTypes]: ButtonProps } = {
   reset: {
     title: "Reset",
     color: "black",
+  },
+  pause: {
+    title: "Pause",
+    color: "orange",
   },
 };
 

--- a/src/StopWatchButton.tsx
+++ b/src/StopWatchButton.tsx
@@ -1,6 +1,12 @@
 import { Button, ButtonProps, View, ViewStyle } from "react-native";
 
-type StopWatchButtonTypes = "start" | "stop" | "lap" | "reset" | "pause";
+type StopWatchButtonTypes =
+  | "start"
+  | "stop"
+  | "lap"
+  | "reset"
+  | "pause"
+  | "resume";
 
 const buttonProps: { [type in StopWatchButtonTypes]: ButtonProps } = {
   start: {
@@ -22,6 +28,10 @@ const buttonProps: { [type in StopWatchButtonTypes]: ButtonProps } = {
   pause: {
     title: "Pause",
     color: "orange",
+  },
+  resume: {
+    title: "Resume",
+    color: "green",
   },
 };
 

--- a/src/util/time.ts
+++ b/src/util/time.ts
@@ -1,0 +1,4 @@
+export const formatTime = (time: number) => {
+  const format = (x: number) => String(Math.floor(x)).padStart(2, "0");
+  return `${format(time / 3600)}:${format((time / 60) % 60)}:${format(time % 60)}`;
+};

--- a/tests/Stopwatch.test.js
+++ b/tests/Stopwatch.test.js
@@ -1,55 +1,71 @@
-import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
-import Stopwatch from '../src/Stopwatch';
+import React from "react";
+import { render, fireEvent, within } from "@testing-library/react-native";
+import Stopwatch from "../src/Stopwatch";
 
-describe('Stopwatch', () => {
-  test('renders initial state correctly', () => {
+describe("Stopwatch", () => {
+  test("renders initial state correctly", () => {
     const { getByText, queryByTestId } = render(<Stopwatch />);
-    
-    expect(getByText('00:00:00')).toBeTruthy();
-    expect(queryByTestId('lap-list')).toBeNull();
+
+    expect(getByText("00:00:00")).toBeTruthy();
+    expect(queryByTestId("lap-list")).toBeNull();
   });
 
-  test('starts and stops the stopwatch', () => {
+  test("starts and stops the stopwatch", () => {
     const { getByText, queryByText } = render(<Stopwatch />);
-    
-    fireEvent.press(getByText('Start'));
+
+    fireEvent.press(getByText("Start"));
     expect(queryByText(/(\d{2}:){2}\d{2}/)).toBeTruthy();
 
-    fireEvent.press(getByText('Stop'));
+    fireEvent.press(getByText("Stop"));
     expect(queryByText(/(\d{2}:){2}\d{2}/)).toBeNull();
   });
 
-  test('pauses and resumes the stopwatch', () => {
+  test("pauses and resumes the stopwatch", async () => {
+    let requestAnimationMock = () => {};
+    jest
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((cb) => (requestAnimationMock = cb));
+
     const { getByText } = render(<Stopwatch />);
-    
-    fireEvent.press(getByText('Start'));
-    fireEvent.press(getByText('Pause'));
-    const pausedTime = getByText(/(\d{2}:){2}\d{2}/).textContent;
 
-    fireEvent.press(getByText('Resume'));
-    expect(getByText(/(\d{2}:){2}\d{2}/).textContent).not.toBe(pausedTime);
+    fireEvent.press(getByText("Start"));
+    fireEvent.press(getByText("Pause"));
+    const pausedTime = getByText(/(\d{2}:){2}\d{2}/).props.children;
+
+    fireEvent.press(getByText("Resume"));
+
+    // Mock two animation frames if needed
+    if (requestAnimationMock) {
+      requestAnimationMock(0);
+    }
+    if (requestAnimationMock) {
+      requestAnimationMock(1000);
+    }
+
+    expect(getByText(/(\d{2}:){2}\d{2}/).props.children).not.toBe(pausedTime);
   });
 
-  test('records and displays lap times', () => {
+  test("records and displays lap times", () => {
     const { getByText, getByTestId } = render(<Stopwatch />);
-    
-    fireEvent.press(getByText('Start'));
-    fireEvent.press(getByText('Lap'));
-    expect(getByTestId('lap-list')).toContainElement(getByText(/(\d{2}:){2}\d{2}/));
 
-    fireEvent.press(getByText('Lap'));
-    expect(getByTestId('lap-list').children.length).toBe(2);
+    fireEvent.press(getByText("Start"));
+    fireEvent.press(getByText("Lap"));
+    expect(
+      within(getByTestId("lap-list")).getByText(/(\d{2}:){2}\d{2}/),
+    ).toBeTruthy();
+
+    fireEvent.press(getByText("Lap"));
+    expect(getByTestId("lap-list").children.length).toBe(2);
   });
 
-  test('resets the stopwatch', () => {
+  test("resets the stopwatch", () => {
     const { getByText, queryByTestId } = render(<Stopwatch />);
-    
-    fireEvent.press(getByText('Start'));
-    fireEvent.press(getByText('Lap'));
-    fireEvent.press(getByText('Reset'));
 
-    expect(getByText('00:00:00')).toBeTruthy();
-    expect(queryByTestId('lap-list')).toBeNull();
+    fireEvent.press(getByText("Start"));
+    fireEvent.press(getByText("Lap"));
+    fireEvent.press(getByText("Reset"));
+
+    expect(getByText("00:00:00")).toBeTruthy();
+    expect(queryByTestId("lap-list")).toBeNull();
   });
 });


### PR DESCRIPTION
This PR adds the Stopwatch features requested in the README in a straightforward and performant way.

Here a quick look into how it looks:
https://github.com/Shopify/eng-intern-assessment-react-native/assets/26513244/04d255de-3598-4f57-abd0-82daed49953c

I used the requestAnimationFrame feature to implement a performant time ticking, which is why I needed to mock it out in one of the tests.

The lap test was not working and (I think) is impossible due to the fact that the laps should be displayed the same way as the timer should. I fixed the test as I think should work. 

I wasn't quite sure which time to display, a stopwatch would suggest milliseconds but the format requested by the tests suggests seconds so I went with this. This can easily be interchanged by just changing the formatTest function in `util/time.ts`

Thank you for this oportunity.
